### PR TITLE
improve concerns filter order

### DIFF
--- a/app/controllers/concerns/admin_controller.rb
+++ b/app/controllers/concerns/admin_controller.rb
@@ -3,7 +3,7 @@ module AdminController
 
   included do
     skip_before_action :authenticate_user!
-    before_action :authenticate_admin!
+    prepend_before_action :authenticate_admin!
   end
 
   def current_role

--- a/app/controllers/concerns/seller_controller.rb
+++ b/app/controllers/concerns/seller_controller.rb
@@ -3,7 +3,7 @@ module SellerController
 
   included do
     skip_before_action :authenticate_user!
-    before_action :authenticate_seller!
+    prepend_before_action :authenticate_seller!
   end
 
   def current_role


### PR DESCRIPTION
concernsが持つ`authenticate_#{role}`フィルタが走る前に本体のフィルタが走るとエラーになるケースがある（`set_product`等）ためをできるだけ前に持ってくる
